### PR TITLE
Consider last layer bias.

### DIFF
--- a/MonDEQ.jl
+++ b/MonDEQ.jl
@@ -113,7 +113,7 @@ function solution_fix_point(x0, W, U, u; η = 1e-10, α = 1e-2, method = "forwar
     return z
 end
 
-function cert(W, U, u, C, n, ϵ, set_input, set_output; me = 0.1307, std = 0.3081)
+function cert(W, U, u, C, c, n, ϵ, set_input, set_output; me = 0.1307, std = 0.3081)
     n_suc = 0; idx_suc = [];
     for k = 1:n
         x0 = (vec(set_input[:,:,k]).-me)./std;
@@ -121,9 +121,9 @@ function cert(W, U, u, C, n, ϵ, set_input, set_output; me = 0.1307, std = 0.308
             if i == set_output[k]+1
                 continue
             else
-                c = C[i,:] - C[set_output[k]+1,:];
-                obj = cert_monDEQ(x0, W, U, u, c, ϵ; nrm = "linf")
-                if obj >= 0
+                ci = C[i,:] - C[set_output[k]+1,:];
+                obj = cert_monDEQ(x0, W, U, u, ci, ϵ; nrm = "linf")
+                if obj >= -c[i] + c[set_output[k]+1]
                     break
                 elseif (i == 10 && set_output[k] <= 8) || (i == 9 && set_output[k] == 9)
                     n_suc += 1

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ For Certification Model, use the following code to compute the ratio of the (fir
 ```Julia
 test_x, test_y = MNIST.testdata();
 vars = matread("deq_MNIST_SingleFcNet_m=20.mat")
-A = vars["A"]; B = vars["B"]; U = vars["U"]; u = vars["u"]; C = vars["C"];
+A = vars["A"]; B = vars["B"]; U = vars["U"]; u = vars["u"]; C = vars["C"]; c = vars["c"];
 p = size(U, 1); m = 20; W = (1-m)*Matrix(I(p))-A'*A+B-B';
 n = 100; std = 0.3081; e = 0.1/std;
-r = cert(W, U, u, C, n, e, test_x, test_y)
+r = cert(W, U, u, C, c, n, e, test_x, test_y)
 ```
 
 For Lipschitz Model, use the following code to compute the ratio of the (first 100) test examples:


### PR DESCRIPTION
Hey,

Thanks for your interesting work and making the corresponding code public. 

When I was looking at the robustness certification in Julia, I noticed, that for the "Robustness Model" the last/classification layer bias is disregarded, such that the certificates only apply to a network where c=0. I think the enclosed changes should fix the issue. As far as I can tell, this fix does not change the results reported in Table 2.

Cheers,
Mark